### PR TITLE
Add information and link to online forum at the index of the non-english help pages

### DIFF
--- a/de/index.md
+++ b/de/index.md
@@ -4,6 +4,15 @@ title: Hilfe - Inhalt
 
 # Hilfe - Inhalt
 
+<div class="panel panel-info">
+  <div class="panel-heading">
+    <strong>Keine Lösung gefunden? Es sind immer noch Fragen offen?</strong>
+  </div>
+  <div class="panel-body">
+    <a class="btn btn-default" role="button" href="http://discourse.jabref.org">Im (englischsprachigen) Onlineforum gibt es weitere Hilfe!</a>
+  </div>
+</div>
+
 ## Allgemeines
 
 -   [Allgemeines](JabRefHelp)

--- a/fr/index.md
+++ b/fr/index.md
@@ -4,6 +4,15 @@ title: Contenu de l'aide
 
 # Contenu de l'aide
 
+<div class="panel panel-info">
+  <div class="panel-heading">
+    <strong>You can't find a solution to your problem? You still have questions?</strong>
+  </div>
+  <div class="panel-body">
+    <a class="btn btn-default" role="button" href="http://discourse.jabref.org">Use the (English) online forum to get more support!</a>
+  </div>
+</div>
+
 ## Général
 
 -   [Informations générales](JabRefHelp)

--- a/fr/index.md
+++ b/fr/index.md
@@ -6,10 +6,10 @@ title: Contenu de l'aide
 
 <div class="panel panel-info">
   <div class="panel-heading">
-    <strong>You can't find a solution to your problem? You still have questions?</strong>
+    <strong>Vous ne trouvez pas de solutions à votre problème&nbsp;? Vous avez encore des questions&nbsp;?</strong>
   </div>
   <div class="panel-body">
-    <a class="btn btn-default" role="button" href="http://discourse.jabref.org">Use the (English) online forum to get more support!</a>
+    <a class="btn btn-default" role="button" href="http://discourse.jabref.org">Demandez de l'aide sur le forum en ligne (en anglais)&nbsp;!</a>
   </div>
 </div>
 

--- a/in/index.md
+++ b/in/index.md
@@ -4,6 +4,15 @@ title: Daftar Isi Bantuan
 
 # Daftar Isi Bantuan
 
+<div class="panel panel-info">
+  <div class="panel-heading">
+    <strong>You can't find a solution to your problem? You still have questions?</strong>
+  </div>
+  <div class="panel-body">
+    <a class="btn btn-default" role="button" href="http://discourse.jabref.org">Use the (English) online forum to get more support!</a>
+  </div>(English) 
+</div>
+
 ## Umum
 
 -   [Informasi Umum](JabRefHelp)

--- a/ja/index.md
+++ b/ja/index.md
@@ -4,6 +4,15 @@ title: ヘルプ目次
 
 # ヘルプ目次
 
+<div class="panel panel-info">
+  <div class="panel-heading">
+    <strong>You can't find a solution to your problem? You still have questions?</strong>
+  </div>
+  <div class="panel-body">
+    <a class="btn btn-default" role="button" href="http://discourse.jabref.org">Use the (English) online forum to get more support!</a>
+  </div>
+</div>
+
 ## 一般
 
 -   [一般的な情報](JabRefHelp)


### PR DESCRIPTION
… as planned in #38 in this PR the recently added link to the forum is also put at the main page of the French, German, Indonesian and Japanese help pages. 

The text shown is:
> **You can't find a solution to your problem? You still have questions?**
> [Use the (English) online forum to get more support!](http://discourse.jabref.org/)

(see the example here: http://help.jabref.org/en/)

@JabRef/translators It would be great if you could provide me a translation to French, Indonesian and Japanese for this small snippet here. You are rather free in your translation - just give me a meaningful reference to the online forum. Thanks in advance!