### PR TITLE
Support GFM syntax in kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,8 +15,12 @@ lsi: false
 #pygments is not supported by GitHub. See https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors
 #See also https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
 #We have to use rouge
+#http://idratherbewriting.com/2016/02/21/bug-with-kramdown-and-rouge-with-github-pages/
 highlighter: rouge
 markdown: kramdown
+  input: GFM
+  auto_ids: true
+  syntax_highlighter: rouge
 
 defaults:
   -

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ kramdown:
   auto_ids: true
   syntax_highlighter: rouge
 
+sass:
+  sass_dir: _sass
 
 defaults:
   -

--- a/_config.yml
+++ b/_config.yml
@@ -15,12 +15,8 @@ lsi: false
 #pygments is not supported by GitHub. See https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors
 #See also https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
 #We have to use rouge
-#http://idratherbewriting.com/2016/02/21/bug-with-kramdown-and-rouge-with-github-pages/
 highlighter: rouge
 markdown: kramdown
-  input: GFM
-  auto_ids: true
-  syntax_highlighter: rouge
 
 defaults:
   -

--- a/_config.yml
+++ b/_config.yml
@@ -15,8 +15,14 @@ lsi: false
 #pygments is not supported by GitHub. See https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors
 #See also https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
 #We have to use rouge
+#http://idratherbewriting.com/2016/02/21/bug-with-kramdown-and-rouge-with-github-pages/
 highlighter: rouge
 markdown: kramdown
+kramdown:
+  input: GFM
+  auto_ids: true
+  syntax_highlighter: rouge
+
 
 defaults:
   -

--- a/_includes/include-before-link.html
+++ b/_includes/include-before-link.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>
+	<link rel="stylesheet" href="../css/main.css">
+ </head>
   <body>
 <a href="{{site.github.repository_url}}/blob/gh-pages/{{page.path}}" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
     <div class="container">

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,16 +1,27 @@
 ---
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
-table{
-    border-collapse: collapse;
-    border-spacing: 0;
-    border:2px solid #ff0000;
-}
-
-th{
-    border:2px solid #000000;
-}
-
-td{
-    border:1px solid #000000;
-}
+table {
+  padding: 0; }
+  table tr {
+    border-top: 1px solid #cccccc;
+    background-color: white;
+    margin: 0;
+    padding: 0; }
+    table tr:nth-child(2n) {
+      background-color: #f8f8f8; }
+    table tr th {
+      font-weight: bold;
+      border: 1px solid #cccccc;
+      text-align: left;
+      margin: 0;
+      padding: 6px 13px; }
+    table tr td {
+      border: 1px solid #cccccc;
+      text-align: left;
+      margin: 0;
+      padding: 6px 13px; }
+    table tr th :first-child, table tr td :first-child {
+      margin-top: 0; }
+    table tr th :last-child, table tr td :last-child {
+margin-bottom: 0; }

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,0 +1,16 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+table{
+    border-collapse: collapse;
+    border-spacing: 0;
+    border:2px solid #ff0000;
+}
+
+th{
+    border:2px solid #000000;
+}
+
+td{
+    border:1px solid #000000;
+}

--- a/en/MsOfficeBibFieldMapping.md
+++ b/en/MsOfficeBibFieldMapping.md
@@ -1,19 +1,19 @@
 ---
 title: MS Office Bibliography xml format
 ---
+<link rel="stylesheet" href="../css/main.css">
+# Field Mapping between MS-Office and JabRef
 
-#Field Mapping between MS-Office and JabRef
-
-##Introduction
+## Introduction
 JabRef supports the MS Office Bibliography xml format for exporting and importing.
 Some field names in the xml format differ from the field names in the BibTeX/BibLaTex format and can therefore be not directly mapped between the formats.
 Therefore this help file provides a list of all field mappings.
 
 
-##Entry Type Mappings
+## Entry Type Mappings
 
 
-| BibTeX/BibLaTex entry type | XML entry type        |
+| BibTeX/BibLaTex entry type | XML entry type       |
 |---------------------------|-----------------------|
 | book                      | Book                  |
 | inbook                    | BookSection           |
@@ -34,10 +34,10 @@ Therefore this help file provides a list of all field mappings.
 | electronic                | ElectronicSource      |
 | online                    | InternetSite          |
 | periodical                | ArticleInAPeriodical  |
+{:.markdown-body}
 
 
-
-##Field mappings
+## Field mappings
 The field mapping for import and export is mostly the same, but there are some differences, as not all field exists in both formats.
 Addtionally, some fields have to be treated different during import/export.
 
@@ -63,7 +63,7 @@ Addtionally, some fields have to be treated different during import/export.
 | authors         | Authors       |
 | editors         | Editors       |
 
-###BibTeX/BibLaTex only fields
+### BibTeX/BibLaTex only fields
 The following fields are BibTeX/BibLaTex only fields, they have no representation in office xml.
 In the resulting xml file they are represented with the prefix `BIBTEX_`
 
@@ -85,7 +85,7 @@ In the resulting xml file they are represented with the prefix `BIBTEX_`
 | &lt;BibTexEntryType&gt;     | BIBTEX_Entry        |
 | &lt;BibTexEntryType&gt;     | SourceType          |
 
-###MS-Bib only fields
+### MS-Bib only fields
 The following fields are XML-only fields, they have no BibTeX/BibLaTex representation:
 In the resulting bib database they are represented with the prefix `msbib-`
 
@@ -121,7 +121,7 @@ In the resulting bib database they are represented with the prefix `msbib-`
 | msbib-counsel                 | counsels                                            |
 
 
-###Special Export treatment
+### Special Export treatment
 The following fields are treated as follows during epxort:
 
 
@@ -143,7 +143,7 @@ The following fields are treated as follows during epxort:
 | &lt;Entry Type is patent&gt; number | PatentNumber   |
 
 
-###Special Import treatment
+### Special Import treatment
 The following fields are treated as follows during import:
 
 

--- a/en/MsOfficeBibFieldMapping.md
+++ b/en/MsOfficeBibFieldMapping.md
@@ -1,7 +1,6 @@
 ---
 title: MS Office Bibliography xml format
 ---
-<link rel="stylesheet" href="../css/main.css">
 # Field Mapping between MS-Office and JabRef
 
 ## Introduction

--- a/en/SearchHelp.md
+++ b/en/SearchHelp.md
@@ -1,6 +1,6 @@
 ---
 title: Searching
-outdated:true
+outdated: true
 ---
 
 # Searching


### PR DESCRIPTION
That may could explain why tables are not rendered correctly...
Source: http://idratherbewriting.com/2016/02/21/bug-with-kramdown-and-rouge-with-github-pages/

Edit// It would be really nice if someone of @JabRef/developers  can test this 