### PR TITLE
Expand readme, add possibility to generate inlcude files, Fix division by zero and typo

### DIFF
--- a/_scripts/README.md
+++ b/_scripts/README.md
@@ -1,11 +1,35 @@
-## Add a new langauge
+## Script overview
+
+The Script has following commands available (each can be shown when called with the help parameter `-h` on any of the positional parameters)
+- `$ python _scrtips/automate.py status [-e|--extended] [-m --markdown]` d
+  - prints the current status to the console
+  - `[-e|--extended]` prints the relevant pages (also applies to the markdown mode)
+  - `[-m --markdown]` write the status int the markdown syntax and opens the file
+  
+
+- `$ python _scrtips/automate.py update [-e|--extended]`
+  - updates all the redirecting pages and the index file of each language as well as the inlcude pages
+  - `[-e|--extended]` prints the relevant pages
+    
+  
+- `$ python _scrtips/automate.py clean [-e|--extended]`
+  - removes all the generated pages, the help site may not work afterwards
+  - `[-e|--extended]` prints the deleted pages
+  
+  
+- `$ python _scrtips/automate.py removeHelpSuffix [-e|--extended]`
+  - removes from all help pages the `Help` suffix and creates redirects for them, this gets also called on each `update`
+  - `[-e|--extended]` prints the renamed pages
+
+
+## Add a new language
 
 Example: Italian (it)
 
 1. Create `it` folder
-1. Create `_includes/link-to-main-it.html` and `link-to-toc-it.html`
-2. Create `_scripts/localization/it.json`
+2. Create `_scripts/localization/it.json` (copy `en.json` and delete/translate the values)
 3. Run `_scripts/automate.py update`
+4. Add the Italian index to the main index if some of the pages are translated into Italian
 
 ## Installatation Notes
 

--- a/_scripts/README.md
+++ b/_scripts/README.md
@@ -1,7 +1,7 @@
 ## Script overview
 
 The Script has following commands available (each can be shown when called with the help parameter `-h` on any of the positional parameters)
-- `$ python _scrtips/automate.py status [-e|--extended] [-m --markdown]` d
+- `$ python _scrtips/automate.py status [-e|--extended] [-m --markdown]` 
   - prints the current status to the console
   - `[-e|--extended]` prints the relevant pages (also applies to the markdown mode)
   - `[-m --markdown]` write the status int the markdown syntax and opens the file

--- a/_scripts/automate.py
+++ b/_scripts/automate.py
@@ -446,11 +446,14 @@ def create_markdown(extended):
         num_pages_not_translated = len(get_not_translated_pages(main_language=MAIN_LANGUAGE, secondary_language=language))
         num_pages_outdated = len(get_outdated_pages(language=language))
         num_pages_old = len(get_old_help_pages_redirecting_to_new_one(language=language))
-        percent_translated = int((1 - num_pages_not_translated / float(num_pages_not_translated + num_pages_translated)) * 100)
-        percent_outdated = int((num_pages_outdated / float(num_pages_translated)) * 100)
+        percent_translated = int((1 - num_pages_not_translated / float(num_pages_not_translated + num_pages_translated)) * 100) \
+            if num_pages_not_translated + num_pages_translated != 0 else 100
+        percent_outdated = int((num_pages_outdated / float(num_pages_translated)) * 100) if num_pages_translated != 0 else 0
+
         markdown_text.append("| {lang} | {translated} | {not_translated} | {outdated} | {old_pages} | {percent_translated} | {percent_outdated} |\n"
             .format(lang=language, translated=num_pages_translated, not_translated=num_pages_not_translated, outdated=num_pages_outdated,
             old_pages=num_pages_old, percent_translated=percent_translated, percent_outdated=percent_outdated))
+
         are_pages_outdated |= num_pages_outdated != 0
         are_pages_not_translated |= num_pages_not_translated != 0
 
@@ -671,7 +674,7 @@ parser_update.add_argument("-e", "--extended", action="store_true", dest="extend
     help="The output is much more sophisticated")
 
 parser_clean = subparser.add_parser(COMMAND_CLEAN,
-    help="Removes all the generated redirect files (CAUTION: index page may not work anymore")
+    help="Removes all the generated redirect files (CAUTION: index page may not work anymore)")
 parser_clean.add_argument("-e", "--extended", action="store_true", dest="extended", default=False,
     help="The output is much more sophisticated")
 

--- a/_scripts/automate.py
+++ b/_scripts/automate.py
@@ -137,6 +137,14 @@ def get_categories_order():
     return json.loads(read_file(FILE_CATEGORIES_ORDER))
 
 
+def get_include_page_path_to_main(language):
+    return "_includes/link-to-main-{}.html".format(language)
+
+
+def get_include_page_path_to_toc(language):
+    return "_includes/link-to-toc-{}.html".format(language)
+
+
 def get_localization(language, key):
     """
     :param language: string
@@ -261,6 +269,16 @@ def delete_all_generated_redirecting_pages(extended):
     """
     for language in get_all_languages():
         deleted_pages = []
+
+        include_page_path_to_main = get_include_page_path_to_main(language=language)
+        if os.path.isfile(include_page_path_to_main):
+            os.remove(include_page_path_to_main)
+            deleted_pages.append(include_page_path_to_main)
+        include_page_path_to_toc = get_include_page_path_to_toc(language=language)
+        if os.path.isfile(include_page_path_to_toc):
+            os.remove(include_page_path_to_toc)
+            deleted_pages.append(include_page_path_to_toc)
+
         if language != MAIN_LANGUAGE:
             deleted_pages = delete_redirecting_help_pages(language=language)
         index = get_local_file_path(language=language, page="index.md")
@@ -510,6 +528,19 @@ def generate_missing_redirects(language):
     return redirected_pages
 
 
+def generate_inlcudes(language):
+    """
+    generates the two layouts `back to main` and `back to toc`
+
+    :param language: string
+    """
+    back_to_mainpage = u"<a href=\"..\">{}</a>\n".format(get_localization(language=language, key="Back to main page"))
+    write_file(filename=get_include_page_path_to_main(language=language), content=back_to_mainpage)
+
+    back_to_mainpage = u"<a href=\".\">{}</a>\n".format(get_localization(language=language, key="Back to table of contents"))
+    write_file(filename=get_include_page_path_to_toc(language=language), content=back_to_mainpage)
+
+
 def update_index(extended):
     """
     updates the index of all languages
@@ -572,6 +603,7 @@ def update_index(extended):
     for language in get_all_languages():
         renamed_pages = remove_help_suffix(language=language)
         redirected_pages = generate_missing_redirects(language=language)
+        generate_inlcudes(language=language)
 
         missing_frontmatter = []
         num_pages_on_index = 0
@@ -610,6 +642,7 @@ def update_index(extended):
         num_renamed_pages = len(renamed_pages)
 
         logger.ok("Language: '{language}'".format(language=language))
+        logger.ok("\tgenerated the 'inlcude' pages")
         logger.ok("\tremoved the 'Help' suffix from {} pages".format(num_renamed_pages))
         if extended and num_renamed_pages != 0:
             logger.neutral("\t\t{}".format(renamed_pages))

--- a/_scripts/localization/de.json
+++ b/_scripts/localization/de.json
@@ -1,4 +1,6 @@
 {
+  "Back to main page": "Zurück zur Hauptseite",
+  "Back to table of contents": "Zurück zum Inhaltsverzeichnis",
   "Help contents": "Hilfe - Inhalt",
   "You can't find a solution to your problem? You still have questions?": "Keine Lösung gefunden? Es sind immer noch Fragen offen?",
   "Use the online forum to get more support!": "Im (englischsprachigen) Onlineforum gibt es weitere Hilfe",

--- a/_scripts/localization/en.json
+++ b/_scripts/localization/en.json
@@ -1,7 +1,9 @@
 {
-  "Help contents":"Help contents",
-  "You can't find a solution to your problem? You still have questions?":"You can't find a solution to your problem? You still have questions?",
-  "Use the online forum to get more support!":"Use the online forum to get more support!",
+  "Back to main page": "Back to main page",
+  "Back to table of contents": "Back to table of contents",
+  "Help contents": "Help contents",
+  "You can't find a solution to your problem? You still have questions?": "You can't find a solution to your problem? You still have questions?",
+  "Use the online forum to get more support!": "Use the online forum to get more support!",
   "General": "General",
   "Fields": "Fields",
   "Finding, sorting and cleaning entries": "Finding, sorting and cleaning entries",

--- a/_scripts/localization/fr.json
+++ b/_scripts/localization/fr.json
@@ -1,4 +1,6 @@
 {
+  "Back to main page": "",
+  "Back to table of contents": "",
   "Help contents": "Contenu de l’aide",
   "You can't find a solution to your problem? You still have questions?": "Vous ne trouvez pas de solutions à votre problème ? Vous avez encore des questions?",
   "Use the online forum to get more support!": "Demandez de l'aide sur le forum en ligne (en anglais)!",

--- a/_scripts/localization/in.json
+++ b/_scripts/localization/in.json
@@ -1,4 +1,6 @@
 {
+  "Back to main page": "",
+  "Back to table of contents": "",
   "Help contents": "Daftar Isi Bantuan",
   "You can't find a solution to your problem? You still have questions?": "",
   "Use the online forum to get more support!": "",

--- a/_scripts/localization/it.json
+++ b/_scripts/localization/it.json
@@ -1,4 +1,6 @@
 {
+  "Back to main page": "",
+  "Back to table of contents": "",
   "Help contents": "",
   "You can't find a solution to your problem? You still have questions?": "",
   "Use the online forum to get more support!": "",

--- a/_scripts/localization/ja.json
+++ b/_scripts/localization/ja.json
@@ -1,4 +1,6 @@
 {
+  "Back to main page": "",
+  "Back to table of contents": "",
   "Help contents": "ヘルプ目次",
   "You can't find a solution to your problem? You still have questions?": "",
   "Use the online forum to get more support!": "",


### PR DESCRIPTION
When a language has no translated pages (in recent events `it`) my script throws a `dvision by zero`-exception.
That and a typo is fixed by this PR.