### PR TITLE
Integration of FAQ into help.jabref.org

### DIFF
--- a/_scripts/categories.json
+++ b/_scripts/categories.json
@@ -1,4 +1,5 @@
 [
+  "FAQ",
   "General",
   "Fields",
   "Finding, sorting and cleaning entries",

--- a/en/FAQcontributing.md
+++ b/en/FAQcontributing.md
@@ -1,0 +1,21 @@
+---
+title: Contributing
+helpCategories: ["FAQ"]
+---
+
+# Contributing
+
+## Q: I am a programmer. How can I join the JabRef project?
+
+A: We follow the usual GitHub pull request approach.
+We have a lot of [open issues](https://github.com/JabRef/jabref/issues).
+If you want to be sure to work on something the core developers currently do not handle, check the [issues tagged with asking-for-a-pull-request](https://github.com/JabRef/jabref/labels/asking-for-a-pull-request).
+See our [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md) for detailed information and further links.
+
+## Q: I would like to help translating JabRef to another language. How do I get started?
+
+A: We encourage you to read [Translating JabRef](https://github.com/JabRef/jabref/wiki/Translating-JabRef).
+
+## Q: Can I make a donation? How?
+
+A: Donations keeps us going! You can use Paypal, Flattr or bank transfers. Your institution/company can contribute too, through bank transfer for example. [All details are given here.](https://github.com/JabRef/jabref/wiki/Donations)

--- a/en/FAQgeneral.md
+++ b/en/FAQgeneral.md
@@ -1,0 +1,174 @@
+---
+title: General
+helpCategories: ["FAQ"]
+---
+
+# General
+
+## Q: My plugins stopped working. What should I do?
+
+A: JabRef v3.0 removed plugin support, because the development team cannot keep up plugin support any more.
+Nevertheless, plugins can be integrated in JabRef.
+See [issue #152](https://github.com/JabRef/jabref/issues/152) for the current status and discussion.
+Please contact the author of the respective plugin and ask him to port his plugin into JabRef's code.
+
+## Q: I am using JabRef in my work. Should I cite JabRef in my publications?
+
+A: You are not obliged to cite JabRef, but we would greatly appreciate it if you do.
+
+{% raw %}
+```
+@Manual{JabRef_software,
+  title = {JabRef},
+  author = {{JabRef Development Team}},
+  year = {2016},
+  url = {http://www.jabref.org}
+}
+```
+{% endraw %}
+
+## Q: Are there any publications dealing with JabRef?
+
+A: We are collecting all publications we hear about at <https://github.com/JabRef/jabref/wiki/JabRef-in-the-media>.
+
+## Q: JabRef does not start. What should I do?
+
+A: This may be because the preferences need to be reset.
+Execute `java -jar JabRef-X.Y.jar --prdef all -n` (with X.Y the version of JabRef).
+On Windows, if that does not help, execute `regedit` and delete the folder `HKEY\_CURRENT\_USER\SOFTWARE\JavaSoft\Prefs\net\sf\jabref`.
+
+## Q: Does JabRef support Chinese characters?
+
+A: Yes. Go to Options-&gt;Preferences-&gt;General-&gt;Default Encoding.
+Set it to UTF8.
+At "Appearance" set table font as simsun (or any other Chinese font).
+At "General", you can change the UI language to Chinese.
+More information are available at <http://yenlung.km.nccu.edu.tw/xms/read_attach.php?id=61> (alternative: <https://web.archive.org/web/20111027034912/http://yenlung.math.nccu.edu.tw/~yenlung/notes/latex_in_Windows.pdf>).
+
+## Q: When I have an instance of Jabref running and double click another BibTeX file it is opened in a new JabRef instance. Is it possible to open it in a new tab in the first instance?
+
+A: Yes. Go to **Options -&gt; Preferences -&gt; Advanced -&gt; “Remote operation”**.
+Put a checkmark to “Listen for remote operation on port:”.
+This option allows new instances of JabRef to detect the instance already running, and pass files to that instead of opening a new window.
+
+## Q: I have a DOI. Is it possible to create an entry directly out of the DOI?
+
+A: Yes. Go to Search and click on “Web Search” to enable the Web search.
+A Web search box appears on the left side of JabRef.
+The name of a web search is selected (e.g. “ACM Portal”).
+Click on it and change it to “DOI to BibTeX”.
+Enter the DOI in the field and press “Fetch”.
+A search starts and the result is displayed in a new pop up window.
+One entry should appear.
+Just push “OK” to insert the entry into the database.
+
+## Q: I have an ISBN. Is it possible to create an entry directly out of the ISBN?
+
+A: Yes. Go to Search and click on “Web Search” to enable the Web search.
+A Web search box appears on the left side of JabRef.
+The name of a web search is selected (e.g. “ACM Portal”).
+Click on it and change it to “ISBN to BibTeX”.
+If a ISBN is not found, head to the [online service](http://manas.tungare.name/software/isbn-to-bibtex/) by Manas Tungare.
+
+## Q: I miss a field translator, lastfollowedon, ... How can I add such fields?
+
+A: To add this “translator“ to all entry types, you can use **Options-&gt;Set up general fields** and add a “translator” field under one of JabRef's general field tabs.
+To add this "translator" to a specific entry type, edit the specific entry type(s) (**Options-&gt;Customize entry types**) and add a “translator“ field under required fields or optional fields, as you like.
+
+
+## Q: How do I prevent JabRef from introducing line breaks in certain fields (such as “title”) when saving the .bib file?
+
+A: Open **Options -&gt; Preferences**.
+In the “File” panel, you will find an option called “Do not wrap the following fields when saving”.
+This option contains a semicolon-separated list of field names.
+Any field you add to this list will always be stored without introduction of line breaks.
+
+## Q: I have a JabRef open. If I open a bibtex file from my web browser, a new JabRef is started. I want the file to be opened in the currently opened JabRef. Is this possible?
+
+A: Yes. Go to **Options -&gt; Preferences -&gt; Advanced -&gt; “Remote operation”**.
+Put a checkmark to “Listen for remote operation on port:”.
+This option allows new instances of JabRef to detect the instance already running, and pass files to that instead of opening a new window.
+Note: This is the default [since JabRef 3.0](https://github.com/JabRef/jabref/blob/master/CHANGELOG.md#30---2015-11-29).
+
+## Q: Is it possible to append entries from a BibTeX file, e.g. from my web browser, to the currently opened database?
+
+A: Yes, you can use the parameter `--importToOpen bibfile`.
+
+## Q: I want to link external files with paths relative to my .bib file, so I can easily move my database along with its files to another directory. Is this possible?
+
+A: Yes. You need to override the default file directory for this specific database.
+Go to **File -&gt; Database properties**. You can override the **Default file directory** setting.
+There, you can either enter the path in **General file directory** (for it to be valid for all users of the file) or in **User-specific file directory** (for it to be valid for you only).
+If you simply enter “.” (a dot, without the quotes), the file directory will be the same as the .bib file directory.
+To place your files in a subdirectory called **subdir**, you can enter **“./subdir”** (without the quotes).
+Files will automatically be linked with relative paths if the files are placed in the default file directory or in a directory below it.
+
+## Q: I want to export my bibliography entries into a simple text file so that I can import them into a spreadsheet easily. Is this possible?
+
+A: Yes. Use **File -&gt; Export**.
+Under “Filter:”, choose “OpenOffice/LibreOffice CSV (\*.csv)”.
+
+## Q: How can I add and remove keywords of multiple entries?
+
+A: Select the entries.
+Right click.
+Choose “Manage keywords”.
+Then you can manage keywords appearing in all selected entries or in any selected entry.
+New keywords are added to all selected entries.
+
+## Q: I want to have a bib-file-specific PDF directory.
+
+A: Right click on the tab of the .bib file.
+Choose “Database properties”.
+Then at the field “General file directory” choose the directory specific for the database.
+If you want to set a directory for you only (so that other users should use the default directory), use the field “User-specific file directory”.
+
+## Q: When linking a file, I cannot set the correct type. How can I add new types?
+
+A: Go to **Options -&gt; Manage external file types**.
+Here you can add arbitrary types.
+
+## Q: Is there a portable version of JabRef?
+
+A: Store the file jabref.jar on the drive.
+It can be opened directly on any computer offering a Java installation by double clicking the `jar` file.
+In **Options-&gt;Preferences-&gt;General**, be sure to activate "Load and Save preferences from/to jabref.xml on start-up (memory stick mode)".
+
+## Q: When an organization is provided as author, my BibTeX style doesn't recognize it. For instance, “European Commission” is converted to “Commission, E.”.
+
+A: Use braces to tell BibTeX to keep your author field as is: `{European Commission}`.
+In BibLaTeX, you can use `label = {EC}` to have `EC05` as label for a publication of the European Commission in the year 2005.
+
+## Q: Is there a FAQ on BibTeX?
+
+A: Yes, please look at “Bibliographies and citations” at the [UK List of TeX Frequently Asked Questions on the Web](http://www.tex.ac.uk/).
+For German readers, there is the [dante e.V. FAQ](http://projekte.dante.de/DanteFAQ/LiteraturVerzeichnis).
+
+## Q: Where is the RenameFile plugin? How to rename file automatically after importing entries?
+
+A: JabRef does not support plugin anymore (version > 2.11). However the plugin features are progressively integrated.
+Renaming of files is now part of the "Cleanup Entries" feature (brush button in the toolbar or CTRL+SHIFT+F7).
+Then, you can rename attached files based on the BibTeX key.  You can change the format (pattern) under
+**Options -&gt; Preferences -&gt; Import**, by altering the pattern under "Default PDF file link action".
+
+## Q: I have a JabRef database and I would like to export a subset to BibTeX (or BibLaTeX) format. How to do this?
+
+A: Your JabRef database is already a file in BibTeX (or BibLaTeX) format. Simply select the entries to be exported, and then
+choose **File-&gt;Save Selected as...**. More details on [stackexchange.com](https://tex.stackexchange.com/questions/82554/jabref-can-it-export-a-subset-of-the-bibliography-in-bibtex-format).
+
+## Q: I have a JabRef database and I would like to export the subset corresponding to my LaTeX file. How to do this?
+
+A: Upon compilation, LaTeX generates a file with the extension ".aux". This files contains the keys of the cited references (among other things). Using this AUX file, JabRef can extract the relevant entries. Choose the menu **Tools-&gt;New subdatabase based on AUX file**. Then select the reference database (among the opened ones), and specify the AUX file.
+
+
+## Q: When I modify my database, I would like that JabRef performs entry cleaning automatically. How to do this?
+
+A: In **File-&gt;Database properties**, you will find a section named "Save actions". After enabling this feature, you can choose which actions should be performed for each field upon saving. That should help you keep your database tidy.
+
+## Q: Search on Google scholar does not work anymore. What is going on?
+
+A: Google scholar is blocking "automated" crawls which generate too much traffic in a short time. JabRef already uses a two-step approach (with the prefetched list before crawling the actual BibTeX data) to circumvent this.
+However, after too much crawls JabRef --- or more correct: your IP address --- is being blocked.
+To unblock your IP, do a Google scholar search in your browser. You will be asked to show that you are not a robot.
+
+Thus, the Google Scholar fetcher is not the best way to obtain lots of entries at the same time. If you are using Mozilla Firefox, the JabRef Plugin "JabFox" might be an alternative to download the BibTeX data directly from the browser. You can find the PlugIn here: https://addons.mozilla.org/en-US/firefox/addon/jabfox/?src=external-jabrefSite

--- a/en/FAQlinux.md
+++ b/en/FAQlinux.md
@@ -1,0 +1,57 @@
+---
+title: JabRef and Linux
+helpCategories: ["FAQ"]
+---
+
+# JabRef and Linux
+
+## Q: JabRef does not start under Linux! What can I do?
+
+A: JabRef works fine under Linux if you use a Java Runtime Environment (JRE) from Oracle version 1.8 and newer ([Downloadable here](https://www.java.com)).
+If running JabRef fails to start nevertheless do the following for troubleshooting:
+
+Run
+
+    java -version
+
+from the command line.
+If this does not report to be a product from Oracle (for instance tells you that it is a GCJ VM) even if you have installed the Oracle JVM then you need to change your setup.
+This is highly dependent on your distribution, so we cannot give exact advise for everybody.
+
+Under Debian/Ubuntu it works like this (you need to have admin privileges):
+
+    sudo update-alternatives --config java
+
+In the dialog that appears select the Oracle JDK or JRE.
+Alternatively you can also search for the java executable and run that directly.
+For example, in Ubuntu 12.04 LTS you can find Java at
+
+    /usr/lib/jvm/java-6-openjdk/jre/bin/java
+
+If you do not have root-access on the machine, you can install the Oracle JRE in your home directory but need to make sure that you run the correct java executable.
+For instance, if you installed the JRE into a folder called
+
+    java
+
+in your home try
+
+    ~/java/jre/bin/java -jar JabRef-X.jar
+
+where 'X' is the JabRef version.
+
+
+## Q: I am on Debian/Ubuntu and clicking on the JabRef icon works, but I cannot start JabRef from the command line.
+What is wrong?
+
+A: You have several Java Virtual Machines installed, and under the command line the wrong one is chosen.
+Have a look at the previous question that tells you how to change the virtual machine used.
+
+For Ubuntu you may also have a look at the [Ubuntu page on Java](https://help.ubuntu.com/community/Java).
+
+
+## Q: Does JabRef run under free Java (Classpath, Kaffee, GCJ, etc.)?
+
+A: As far as we know, JabRef is not yet running on these free JVMs, due of our dependencies.
+However, JabRef is reported to run nicely on the [IcedTea](http://fedoraproject.org/wiki/Features/IcedTea) runtime, which is based on the [OpenJDK](http://openjdk.java.net/) built with [GNU Classpath](http://www.gnu.org/software/classpath/) to fill in missing classes. Some issues have been encountered with the LookAndFell (see [Issue #393](https://github.com/JabRef/jabref/issues/393)).
+Please let us know if newer versions give different results.
+If you have an idea or the expertise to make JabRef work under Classpath, let us know.

--- a/en/FAQosx.md
+++ b/en/FAQosx.md
@@ -1,0 +1,32 @@
+---
+title: JabRef and Mac OS X
+helpCategories: ["FAQ"]
+---
+
+# JabRef and Mac OS X
+
+## Q: After downloading and unzipping, OS X shows “the package was damaged and moved to trash”
+
+A: On Mac OS X Lion, it is possible to resolve it by temporarily changing the Gate Keeper security settings under “Security&Privacy” in the system preferences to “Anywhere”.
+After that you can open the JabRef app.
+When you have opened it once, you can change the security settings back and you'll still be able to open the app.
+
+## Q: There is no explicit Mac OS X application for JabRef 2.11
+
+A: We were not able to generate a working version of JabRef 2.11 for Mac OS X.
+Please use the jar of version 2.11, or look at the newer 3.X versions (which fully supports Mac OS X again).
+
+## Q: Is it possible to upgrade directly from JabRef 2.x to JabRef 3.x?
+
+A: Due to the change of the installer for 3.x it is required to perform a clean install of any JabRef 3.x version.
+You are required to remove any previously installed JabRef 2.x application from the "Applications" folder.
+Then you can install the latest JabRef 3.x version with the installer.
+As soon you are running on any JabRef 3.x version, you can use the installer to upgrade JabRef.
+
+## Q: I am trying to install JabRef, but I am blocked by "JabRef Installer can’t be opened because it is from an unidentified developer."
+
+A: To override that, Ctrl+click instead, and choose "open", which gives the same warning but the possibility to override it. then you can install.
+
+## Q: I am trying to install JabRef, but I am blocked by  "JabRef Installer error: Error downloading the Java(TM) Runtime Environment. Please check your internet connection and start setup again."
+
+A: The problem is caused because you do not have Java 8 installed, and the automatic download and installation is somehow failing... It can be downloaded here manually: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html

--- a/en/FAQother.md
+++ b/en/FAQother.md
@@ -1,0 +1,15 @@
+---
+title: Other
+helpCategories: ["FAQ"]
+---
+
+# Other
+
+## Q: My question is not answered here. What can I do?
+
+A: After consulting [JabRef's help](http://help.jabref.org/) and checking whether your question has been [regarded as issue](https://github.com/JabRef/jabref/issues?utf8=%E2%9C%93&q=is%3Aissue+), please head over to the [mailinglist](https://lists.sourceforge.net/lists/listinfo/jabref-users) or to [StackExchange](https://tex.stackexchange.com/tags/jabref/).
+
+## Q: There is a mistake in this FAQ, a dead link or I have written a better/new explanation for a question!
+
+A: Either click on `View on GitHub` or fork the [www.jabref.org](https://github.com/JabRef/www.jabref.org) repository, do your changes and create a pull request.
+Remember not to use your master branch, but name your branch differently.

--- a/en/FAQsharing.md
+++ b/en/FAQsharing.md
@@ -1,0 +1,18 @@
+---
+title: Sharing
+helpCategories: ["FAQ"]
+---
+
+# Sharing
+
+## Q: How does JabRef support me in sharing my BibTeX libraries?
+
+A: JabRef automatically recognizes a change in the `bib` file on disk and notifies the user of it.
+This is cool for network drives.
+If you use version control, we recommend to right click on the tab of the database, click on "database properties", and define a sort order on the file.
+We recommend, year, author, title.
+In addition, we have [many open issues dealing with collaboration](https://github.com/JabRef/jabref/wiki/FeatureRequests-Sorted#allow-me-to-work-with-others-please).
+
+## Q: How to do collaborative work on a library?
+
+A: You can either choose to [use an SQL database](http://help.jabref.org/en/SQLDatabase) or to [share a bib file](http://help.jabref.org/en/SharedBibFile).

--- a/en/FAQwindows.md
+++ b/en/FAQwindows.md
@@ -1,0 +1,20 @@
+---
+title: JabRef and Windows
+helpCategories: ["FAQ"]
+---
+
+# JabRef and Windows
+
+## Q: How can I use JabRef as backend for Microsoft Word?
+
+A: You can directly use the references in Word's internal reference manager.
+Short explanation: Export your bibliography in XML format and replace the Sources.xml in `%APPDATA%\Roaming\Microsoft\Bibliography`.
+Long explanation: see [Using JabRef references in Word document](http://www.ademcan.net/?d=2012/01/30/15/23/05-using-jabref-references-in-word-documents).
+
+Another option is to use [BibteX4Word](http://www.ee.ic.ac.uk/hp/staff/dmb/perl/index.html).
+
+The last option is to use [Docear4Word](https://github.com/Docear/Docear4Word), which is planned to be ported to JabRef (see [JabRef4Word](https://github.com/JabRef/JabRef4Word)).
+
+## Q: How can I start or focus JabRef with hotkey Windows+J?
+
+A: Use [AutoHotkey](http://www.autohotkey.com/) and [JabRef.ahk](https://github.com/koppor/autohotkey-scripts/blob/master/JabRef.ahk) provided at [koppor's autohotkey scripts](https://github.com/koppor/autohotkey-scripts).

--- a/en/localization_en.json
+++ b/en/localization_en.json
@@ -4,6 +4,7 @@
   "Help contents": "Help contents",
   "You can't find a solution to your problem? You still have questions?": "You can't find a solution to your problem? You still have questions?",
   "Use the online forum to get more support!": "Use the online forum to get more support!",
+  "FAQ": "FAQ",
   "General": "General",
   "Fields": "Fields",
   "Finding, sorting and cleaning entries": "Finding, sorting and cleaning entries",

--- a/fr/localization_fr.json
+++ b/fr/localization_fr.json
@@ -4,6 +4,7 @@
   "Help contents": "Contenu de l’aide",
   "You can't find a solution to your problem? You still have questions?": "Vous ne trouvez pas de solutions à votre problème ? Vous avez encore des questions?",
   "Use the online forum to get more support!": "Demandez de l'aide sur le forum en ligne (en anglais)!",
+  "FAQ": "FAQ",
   "General": "Général",
   "Fields": "Champs",
   "Finding, sorting and cleaning entries": "Recherche et tri des entrées",


### PR DESCRIPTION
Responding to issue https://github.com/JabRef/help.jabref.org/issues/44 and https://github.com/JabRef/www.jabref.org/pull/59

Rational to put the FAQ at the top of the index:
- JabRef users are likely to display directly the relevant help page by clicking on the button (so, for them the order is not so relevant)
- "You can't find a solution to your problem? You still have questions?" is although at the top
- Since these are frequently-asked questions, users should frequently find answers there.

To do (somewhere else, by somebody more skilled than me about the website):
- [ ] remove FAQ files from www.jabref.org
- [ ] rework the help section of www.jabref.org
