### PR TITLE
Information on header information added by JabRef

### DIFF
--- a/en/Bibtex.md
+++ b/en/Bibtex.md
@@ -7,6 +7,22 @@ helpCategories: ["Fields"]
 
 JabRef helps you work with your *BibTeX* databases, but there are still rules to keep in mind when editing your entries, to ensure that your database is treated properly by the *BibTeX* program.
 
+## JabRef's conventions
+
+### Fields in the header of a bib file
+
+JabRef stores the encoding of the file and (in case a shared [SQL database](https://help.jabref.org/en/SQLDatabase) is used) the ID of the shared database in the header of the bib file.
+
+#### Encoding
+
+`% Encoding: <encoding>`: States the encoding of a BibTeX file. E.g., `% Encoding: UTF-8`
+
+#### Shared Id
+
+To enable [auto save](https://help.jabref.org/en/Autosave), JabRef adds `% DBID: <id>` to the header.
+This helps JabRef identifying the SQL database where the file belongs.
+E.g., `% DBID: 2mvhh73ge3hc5fosdsvuoa808t`.
+
 ## Standard *BibTeX* fields
 
 There is a lot of different fields in *BibTeX*, and some additional fields that you can set in JabRef.

--- a/en/Bibtex.md
+++ b/en/Bibtex.md
@@ -11,7 +11,7 @@ JabRef helps you work with your *BibTeX* databases, but there are still rules to
 
 ### Fields in the header of a bib file
 
-JabRef stores the encoding of the file and (in case a shared [SQL database](https://help.jabref.org/en/SQLDatabase) is used) the ID of the shared database in the header of the bib file.
+JabRef stores the encoding of the file and (in case a shared [SQL database](SQLDatabase) is used) the ID of the shared database in the header of the bib file.
 
 #### Encoding
 
@@ -19,7 +19,7 @@ JabRef stores the encoding of the file and (in case a shared [SQL database](http
 
 #### Shared Id
 
-To enable [auto save](https://help.jabref.org/en/Autosave), JabRef adds `% DBID: <id>` to the header.
+To enable [auto save](Autosave), JabRef adds `% DBID: <id>` to the header.
 This helps JabRef identifying the SQL database where the file belongs.
 E.g., `% DBID: 2mvhh73ge3hc5fosdsvuoa808t`.
 


### PR DESCRIPTION
In the course of https://github.com/JabRef/jabref/pull/2118/files#r83008488, @koppor and me thought, it would be a good idea to document the header comments generated by JabRef. Not placed it into the Wiki (e.g., https://github.com/JabRef/jabref/wiki/BibTeX), because this is very interesting for the end users.