### PR TITLE
Renaming "Help on Strings" into "Strings"

### DIFF
--- a/en/Strings.md
+++ b/en/Strings.md
@@ -1,9 +1,9 @@
 ---
-title: Help on Strings
+title: Strings
 helpCategories: ["Fields"]
 ---
 
-# Help on Strings
+# Strings
 
 *BibTeX* supports storing constant strings using `@String {key = value}`. JabRef supports managing them using **BibTeX -&gt; Edit strings**, which opens the [String Editor](StringEditorHelp). These values can be used in fields. For example, you can have:
 


### PR DESCRIPTION
No need to specify "Help" in the title for a document located in the help repository.