### PR TITLE
fix index order

### DIFF
--- a/_scripts/automate.py
+++ b/_scripts/automate.py
@@ -606,7 +606,7 @@ def update_index(extended):
         :param indentation: int: how much the category is indented
         """
         # 2 loops to write the link before subsections
-        for key, value in sorted(index.iteritems()):
+        for key, value in sorted(index.items(), key=lambda x:x[1]):
             if type(value) is not dict:
                 index_file.append(u"- [{title}]({link})\n".format(title=value, link=key))
 

--- a/de/index.md
+++ b/de/index.md
@@ -15,48 +15,48 @@ title: Hilfe - Inhalt
 
 
 ## FAQ
-- [Contributing](/de/FAQcontributing)
 - [General](/de/FAQgeneral)
 - [JabRef and Linux](/de/FAQlinux)
 - [JabRef and Mac OS X](/de/FAQosx)
+- [JabRef and Windows](/de/FAQwindows)
 - [Other](/de/FAQother)
 - [Sharing](/de/FAQsharing)
-- [JabRef and Windows](/de/FAQwindows)
+- [貢献方法](/de/FAQcontributing)
 
 
 ## Allgemeines
 - [Autosave](/de/Autosave)
 - [Backup](/de/Backup)
-- [Das Hauptfenster von JabRef](/de/BaseFrame)
 - [Best Practices](/de/BestPractices)
-- [Kommandozeilen-Optionen](/de/CommandLine)
+- [Das Hauptfenster von JabRef](/de/BaseFrame)
 - [Der Eintrags-Editor](/de/EntryEditor)
+- [Externer Zugriff](/de/Remote)
 - [Installation](/de/Installation)
 - [JabRef](/de/JabRef)
-- [Externer Zugriff](/de/Remote)
+- [Kommandozeilen-Optionen](/de/CommandLine)
 
 
 ## Felder
-- [Über *BibTeX*](/de/Bibtex)
-- [Wortauswahl verwalten](/de/ContentSelector)
-- [Links zu PDF- und PS-Dateien, URLs und DOIs in JabRef](/de/ExternalFiles)
-- [Datei-Links in JabRef](/de/FileLinks)
-- [Zeitschriftentitel abkürzen](/de/JournalAbbreviations)
 - [Das 'Besitzer' (owner) Feld](/de/Owner)
+- [Datei-Links in JabRef](/de/FileLinks)
+- [Links zu PDF- und PS-Dateien, URLs und DOIs in JabRef](/de/ExternalFiles)
 - [Set/clear/rename fields](/de/SetClearRenameFields)
 - [Special Fields](/de/SpecialFields)
 - [Strings](/de/Strings)
+- [Wortauswahl verwalten](/de/ContentSelector)
+- [Zeitschriftentitel abkürzen](/de/JournalAbbreviations)
 - [Zeitstempel](/de/TimeStamp)
+- [Über *BibTeX*](/de/Bibtex)
 
 
 ## Einträge finden und sortieren
+- [Add unlinked PDFs including BibTeX data into the database](/de/FindUnlinkedFiles)
 - [Check integrity](/de/CheckIntegrity)
 - [Cleanup entries](/de/CleanupEntries)
+- [Einträge markieren](/de/Marking)
 - [Find duplicates](/de/FindDuplicates)
-- [Add unlinked PDFs including BibTeX data into the database](/de/FindUnlinkedFiles)
 - [Get BibTeX data from DOI](/de/GetBibTeXDataFromDOI)
 - [Gruppen](/de/Groups)
-- [Einträge markieren](/de/Marking)
 - [Merge entries](/de/MergeEntries)
 - [Replace string](/de/ReplaceString)
 - [Save actions](/de/SaveActions)
@@ -65,33 +65,33 @@ title: Hilfe - Inhalt
 
 
 ## Einstellungen
+- [Allgemeine Felder festlegen](/de/GeneralFields)
 - [Anpassen der automatischen Erstellung von BibTeX-Keys](/de/BibtexKeyPatterns)
-- [Eintragstypen anpassen](/de/CustomEntryTypes)
 - [Customize key bindings](/de/CustomKeyBindings)
 - [Database properties window](/de/DatabaseProperties)
-- [Manage external file types](/de/ExternalFileTypes)
-- [Allgemeine Felder festlegen](/de/GeneralFields)
-- [Eintragsvorschau einstellen](/de/Preview)
-- [Manage protected terms](/de/ProtectedTerms)
 - [Der String-Editor](/de/StringEditor)
+- [Eintragstypen anpassen](/de/CustomEntryTypes)
+- [Eintragsvorschau einstellen](/de/Preview)
+- [Manage external file types](/de/ExternalFileTypes)
+- [Manage protected terms](/de/ProtectedTerms)
 
 
 ## Gemeinsames arbeiten
-- [Shared SQL Database](/de/SQLDatabase)
 - [Migration of pre-3.6 SQL databases into a shared SQL database](/de/SQLDatabaseMigration)
+- [Shared SQL Database](/de/SQLDatabase)
 - [Sharing a Bib(La)TeX Database](/de/SharedBibFile)
 
 
 ## Import/Export
-- [Exportfilter anpassen](/de/CustomExports)
-- [Importfilter anpassen](/de/CustomImports)
 - [EndNote Exportfilter](/de/EndNoteFilters)
-- [Import-Kontrollfenster](/de/ImportInspectionDialog)
-- [Medline (txt) vs. Medline (XML) vs. RIS](/de/MedlineRIS)
-- [MS Office Bibliography xml format](/de/MsOfficeBibFieldMapping)
-- [New subdatabase based on AUX file](/de/NewBasedOnAux)
-- [JabRef-Bibliographien in OpenOffice.org benutzen](/de/OpenOfficeIntegration)
 - [Export to an External SQL Database](/de/SQLExport)
+- [Exportfilter anpassen](/de/CustomExports)
+- [Import-Kontrollfenster](/de/ImportInspectionDialog)
+- [Importfilter anpassen](/de/CustomImports)
+- [JabRef-Bibliographien in OpenOffice.org benutzen](/de/OpenOfficeIntegration)
+- [MS Office Bibliography xml format](/de/MsOfficeBibFieldMapping)
+- [Medline (txt) vs. Medline (XML) vs. RIS](/de/MedlineRIS)
+- [New subdatabase based on AUX file](/de/NewBasedOnAux)
 - [Unterstützung von XMP-Metadaten in JabRef](/de/XMP)
 
 
@@ -99,28 +99,28 @@ title: Hilfe - Inhalt
 
 
 ### ... über Veröffentlichungskennung
-- [Creating entries from SAO/NASA Astrophysics Data System](/de/ADStoBibTeX)
-- [Creating entries using the Digital Object Identifier (DOI)](/de/DOItoBibTeX)
 - [Creating entries from DiVA](/de/DiVAtoBibTeX)
-- [Creating entries using an ISBN number](/de/ISBNtoBibTeX)
 - [Creating entries from Medline](/de/MedlinetoBibTeX)
+- [Creating entries from SAO/NASA Astrophysics Data System](/de/ADStoBibTeX)
+- [Creating entries using an ISBN number](/de/ISBNtoBibTeX)
+- [Creating entries using the Digital Object Identifier (DOI)](/de/DOItoBibTeX)
 
 
 ### ... über Online-Datenbanken
-- [Fetching entries from ACM Portal](/de/ACMPortal)
-- [Fetching entries from SAO/NASA Astrophysics Data System](/de/ADS)
 - [CiteSeer-Import](/de/CiteSeer)
+- [Einträge von Medline abrufen](/de/Medline)
+- [Fetching entries from ACM Portal](/de/ACMPortal)
 - [Fetching entries from DBLP](/de/DBLP)
 - [Fetching entries from DOAJ](/de/DOAJ)
 - [Fetching entries from GVK](/de/GVK)
 - [Fetching entries from Google Scholar](/de/GoogleScholar)
-- [IEEEXplore durchsuchen](/de/IEEEXplore)
-- [INSPIRE-Suche](/de/INSPIRE)
 - [Fetching entries from MathSciNet](/de/MathSciNet)
-- [Einträge von Medline abrufen](/de/Medline)
+- [Fetching entries from SAO/NASA Astrophysics Data System](/de/ADS)
 - [Fetching entries from Springer](/de/Springer)
 - [Fetching entries from arXiv](/de/arXiv)
 - [Fetching entries from zbMATH](/de/zbMATH)
+- [IEEEXplore durchsuchen](/de/IEEEXplore)
+- [INSPIRE-Suche](/de/INSPIRE)
 
 
 

--- a/en/index.md
+++ b/en/index.md
@@ -15,45 +15,45 @@ title: Help contents
 
 
 ## FAQ
-- [Contributing](/en/FAQcontributing)
 - [General](/en/FAQgeneral)
 - [JabRef and Linux](/en/FAQlinux)
 - [JabRef and Mac OS X](/en/FAQosx)
+- [JabRef and Windows](/en/FAQwindows)
 - [Other](/en/FAQother)
 - [Sharing](/en/FAQsharing)
-- [JabRef and Windows](/en/FAQwindows)
+- [貢献方法](/en/FAQcontributing)
 
 
 ## General
 - [Autosave](/en/Autosave)
 - [Backup](/en/Backup)
-- [The JabRef main window](/en/BaseFrame)
 - [Best Practices](/en/BestPractices)
 - [Command line use and options](/en/CommandLine)
-- [The entry editor](/en/EntryEditor)
 - [Installation](/en/Installation)
 - [JabRef](/en/JabRef)
 - [Remote operation](/en/Remote)
+- [The JabRef main window](/en/BaseFrame)
+- [The entry editor](/en/EntryEditor)
 
 
 ## Fields
 - [About *BibTeX*](/en/Bibtex)
+- [Entry time stamps](/en/TimeStamp)
 - [Field content selector](/en/ContentSelector)
-- [PDF/PS/URL/DOI links in JabRef](/en/ExternalFiles)
 - [File links in JabRef](/en/FileLinks)
 - [Journal abbreviations](/en/JournalAbbreviations)
-- [The 'owner' field](/en/Owner)
+- [PDF/PS/URL/DOI links in JabRef](/en/ExternalFiles)
 - [Set/clear/rename fields](/en/SetClearRenameFields)
 - [Special Fields](/en/SpecialFields)
 - [Strings](/en/Strings)
-- [Entry time stamps](/en/TimeStamp)
+- [The 'owner' field](/en/Owner)
 
 
 ## Finding, sorting and cleaning entries
+- [Add unlinked PDFs including BibTeX data into the database](/en/FindUnlinkedFiles)
 - [Check integrity](/en/CheckIntegrity)
 - [Cleanup entries](/en/CleanupEntries)
 - [Find duplicates](/en/FindDuplicates)
-- [Add unlinked PDFs including BibTeX data into the database](/en/FindUnlinkedFiles)
 - [Get BibTeX data from DOI](/en/GetBibTeXDataFromDOI)
 - [Groups](/en/Groups)
 - [Mark entries](/en/Marking)
@@ -65,33 +65,33 @@ title: Help contents
 
 
 ## Setup
-- [Customizing the BibTeX key generator](/en/BibtexKeyPatterns)
-- [Customizing entry types](/en/CustomEntryTypes)
 - [Customize key bindings](/en/CustomKeyBindings)
-- [Database properties window](/en/DatabaseProperties)
-- [Manage external file types](/en/ExternalFileTypes)
+- [Customizing entry types](/en/CustomEntryTypes)
 - [Customizing general fields](/en/GeneralFields)
+- [Customizing the BibTeX key generator](/en/BibtexKeyPatterns)
+- [Database properties window](/en/DatabaseProperties)
 - [Entry preview setup](/en/Preview)
+- [Manage external file types](/en/ExternalFileTypes)
 - [Manage protected terms](/en/ProtectedTerms)
 - [The string editor](/en/StringEditor)
 
 
 ## Collaborative work
-- [Shared SQL Database](/en/SQLDatabase)
 - [Migration of pre-3.6 SQL databases into a shared SQL database](/en/SQLDatabaseMigration)
+- [Shared SQL Database](/en/SQLDatabase)
 - [Sharing a Bib(La)TeX Database](/en/SharedBibFile)
 
 
 ## Import/Export
+- [Comparison of the Medline (txt), Medline (XML), and RIS format](/en/MedlineRIS)
 - [Custom export filters](/en/CustomExports)
 - [Custom import filters](/en/CustomImports)
 - [EndNote Export Filter](/en/EndNoteFilters)
+- [Export to an External SQL Database](/en/SQLExport)
 - [Import inspection window](/en/ImportInspectionDialog)
-- [Comparison of the Medline (txt), Medline (XML), and RIS format](/en/MedlineRIS)
 - [MS Office Bibliography xml format](/en/MsOfficeBibFieldMapping)
 - [New subdatabase based on AUX file](/en/NewBasedOnAux)
 - [OpenOffice/LibreOffice integration](/en/OpenOfficeIntegration)
-- [Export to an External SQL Database](/en/SQLExport)
 - [XMP metadata support in JabRef](/en/XMP)
 
 
@@ -99,16 +99,15 @@ title: Help contents
 
 
 ### ... using publication identifiers
-- [Creating entries from SAO/NASA Astrophysics Data System](/en/ADStoBibTeX)
-- [Creating entries using the Digital Object Identifier (DOI)](/en/DOItoBibTeX)
 - [Creating entries from DiVA](/en/DiVAtoBibTeX)
-- [Creating entries using an ISBN number](/en/ISBNtoBibTeX)
 - [Creating entries from Medline](/en/MedlinetoBibTeX)
+- [Creating entries from SAO/NASA Astrophysics Data System](/en/ADStoBibTeX)
+- [Creating entries using an ISBN number](/en/ISBNtoBibTeX)
+- [Creating entries using the Digital Object Identifier (DOI)](/en/DOItoBibTeX)
 
 
 ### ... using online bibliographic database
 - [Fetching entries from ACM Portal](/en/ACMPortal)
-- [Fetching entries from SAO/NASA Astrophysics Data System](/en/ADS)
 - [Fetching entries from CiteSeerX](/en/CiteSeer)
 - [Fetching entries from DBLP](/en/DBLP)
 - [Fetching entries from DOAJ](/en/DOAJ)
@@ -116,8 +115,9 @@ title: Help contents
 - [Fetching entries from Google Scholar](/en/GoogleScholar)
 - [Fetching entries from IEEEXplore](/en/IEEEXplore)
 - [Fetching entries from INSPIRE-HEP](/en/INSPIRE)
-- [Fetching entries from MathSciNet](/en/MathSciNet)
 - [Fetching entries from MEDLINE](/en/Medline)
+- [Fetching entries from MathSciNet](/en/MathSciNet)
+- [Fetching entries from SAO/NASA Astrophysics Data System](/en/ADS)
 - [Fetching entries from Springer](/en/Springer)
 - [Fetching entries from arXiv](/en/arXiv)
 - [Fetching entries from zbMATH](/en/zbMATH)

--- a/fr/index.md
+++ b/fr/index.md
@@ -15,83 +15,83 @@ title: Contenu de l’aide
 
 
 ## FAQ
-- [Contributing](/fr/FAQcontributing)
 - [General](/fr/FAQgeneral)
 - [JabRef and Linux](/fr/FAQlinux)
 - [JabRef and Mac OS X](/fr/FAQosx)
+- [JabRef and Windows](/fr/FAQwindows)
 - [Other](/fr/FAQother)
 - [Sharing](/fr/FAQsharing)
-- [JabRef and Windows](/fr/FAQwindows)
+- [貢献方法](/fr/FAQcontributing)
 
 
 ## Général
-- [Sauvegarde automatique](/fr/Autosave)
+- [Accès à distance](/fr/Remote)
 - [Backup](/fr/Backup)
-- [La fenêtre principale de JabRef](/fr/BaseFrame)
 - [Best Practices](/fr/BestPractices)
-- [Les options de la ligne de commande](/fr/CommandLine)
-- [L'éditeur d'entrées](/fr/EntryEditor)
 - [Installation](/fr/Installation)
 - [JabRef](/fr/JabRef)
-- [Accès à distance](/fr/Remote)
+- [L'éditeur d'entrées](/fr/EntryEditor)
+- [La fenêtre principale de JabRef](/fr/BaseFrame)
+- [Les options de la ligne de commande](/fr/CommandLine)
+- [Sauvegarde automatique](/fr/Autosave)
 
 
 ## Champs
 - [A propos de *BibTeX*](/fr/Bibtex)
-- [Sélecteur de contenu de champ](/fr/ContentSelector)
+- [Abréviations des journaux](/fr/JournalAbbreviations)
+- [Aide sur les chaînes](/fr/Strings)
+- [Champs spéciaux](/fr/SpecialFields)
+- [Horodatage des entrées](/fr/TimeStamp)
+- [Le champ 'owner' (propriétaire)](/fr/Owner)
 - [Les liens PDF/PS/URL/DOI dans JabRef](/fr/ExternalFiles)
 - [Liens de fichier dans JabRef](/fr/FileLinks)
-- [Abréviations des journaux](/fr/JournalAbbreviations)
-- [Le champ 'owner' (propriétaire)](/fr/Owner)
 - [Set/clear/rename fields](/fr/SetClearRenameFields)
-- [Champs spéciaux](/fr/SpecialFields)
-- [Aide sur les chaînes](/fr/Strings)
-- [Horodatage des entrées](/fr/TimeStamp)
+- [Sélecteur de contenu de champ](/fr/ContentSelector)
 
 
 ## Recherche et tri des entrées
+- [Add unlinked PDFs including BibTeX data into the database](/fr/FindUnlinkedFiles)
 - [Check integrity](/fr/CheckIntegrity)
 - [Cleanup entries](/fr/CleanupEntries)
+- [Etiqueter les entrées](/fr/Marking)
 - [Find duplicates](/fr/FindDuplicates)
-- [Add unlinked PDFs including BibTeX data into the database](/fr/FindUnlinkedFiles)
 - [Get BibTeX data from DOI](/fr/GetBibTeXDataFromDOI)
 - [Les groupes](/fr/Groups)
-- [Etiqueter les entrées](/fr/Marking)
 - [Merge entries](/fr/MergeEntries)
+- [Recherche](/fr/Search)
 - [Replace string](/fr/ReplaceString)
 - [Save actions](/fr/SaveActions)
-- [Recherche](/fr/Search)
 - [Synchronize file links](/fr/SynchroFileLinks)
 
 
 ## Configuration
+- [Configuration de l'aperçu des entrées](/fr/Preview)
+- [Customize key bindings](/fr/CustomKeyBindings)
+- [L'éditeur de chaîne](/fr/StringEditor)
+- [Manage external file types](/fr/ExternalFileTypes)
+- [Manage protected terms](/fr/ProtectedTerms)
+- [Personnalisation des champs généraux](/fr/GeneralFields)
 - [Personnalisation du générateur de clefs BibTeX](/fr/BibtexKeyPatterns)
 - [Personnaliser les types d'entrées](/fr/CustomEntryTypes)
-- [Customize key bindings](/fr/CustomKeyBindings)
 - [Propriétés de la base de données.](/fr/DatabaseProperties)
-- [Manage external file types](/fr/ExternalFileTypes)
-- [Personnalisation des champs généraux](/fr/GeneralFields)
-- [Configuration de l'aperçu des entrées](/fr/Preview)
-- [Manage protected terms](/fr/ProtectedTerms)
-- [L'éditeur de chaîne](/fr/StringEditor)
 
 
 ## Travail collaboratif
-- [Shared SQL Database](/fr/SQLDatabase)
 - [Migration of pre-3.6 SQL databases into a shared SQL database](/fr/SQLDatabaseMigration)
+- [Shared SQL Database](/fr/SQLDatabase)
 - [Sharing a Bib(La)TeX Database](/fr/SharedBibFile)
 
 
 ## Importation/Exportation
+- [Comparison of the Medline (txt), Medline (XML), and RIS format](/fr/MedlineRIS)
+- [Exportation vers une base de données SQL externe](/fr/SQLExport)
+- [Fenêtre de vérification des importations](/fr/ImportInspectionDialog)
+- [Filtre d'exportation EndNote](/fr/EndNoteFilters)
 - [Filtres d'exportation personnalisés](/fr/CustomExports)
 - [Filtres d'importation personnalisés](/fr/CustomImports)
-- [Filtre d'exportation EndNote](/fr/EndNoteFilters)
-- [Fenêtre de vérification des importations](/fr/ImportInspectionDialog)
-- [Comparison of the Medline (txt), Medline (XML), and RIS format](/fr/MedlineRIS)
+- [Intégration dans OpenOffice/LibreOffice](/fr/OpenOfficeIntegration)
 - [MS Office Bibliography xml format](/fr/MsOfficeBibFieldMapping)
 - [New subdatabase based on AUX file](/fr/NewBasedOnAux)
-- [Intégration dans OpenOffice/LibreOffice](/fr/OpenOfficeIntegration)
-- [Exportation vers une base de données SQL externe](/fr/SQLExport)
 - [Support des metadonnées XMP dans JabRef](/fr/XMP)
 
 
@@ -99,28 +99,28 @@ title: Contenu de l’aide
 
 
 ### ... en utilisant des identifiants de publication
-- [Creating entries from SAO/NASA Astrophysics Data System](/fr/ADStoBibTeX)
-- [Récupération d'entrées en utilisant l'identifiant d'objet numérique (DOI)](/fr/DOItoBibTeX)
-- [Récupération d'entrées en utilisant DiVA](/fr/DiVAtoBibTeX)
-- [Récupération d'entrées à partir du numéro ISBN](/fr/ISBNtoBibTeX)
 - [Creating entries from Medline](/fr/MedlinetoBibTeX)
+- [Creating entries from SAO/NASA Astrophysics Data System](/fr/ADStoBibTeX)
+- [Récupération d'entrées en utilisant DiVA](/fr/DiVAtoBibTeX)
+- [Récupération d'entrées en utilisant l'identifiant d'objet numérique (DOI)](/fr/DOItoBibTeX)
+- [Récupération d'entrées à partir du numéro ISBN](/fr/ISBNtoBibTeX)
 
 
 ### ... en utilisant une base de données bibliographique en ligne
-- [Récupération d'entrées depuis le portail *ACM*](/fr/ACMPortal)
-- [Fetching entries from SAO/NASA Astrophysics Data System](/fr/ADS)
-- [Récupération d'entrées depuis CiteSeerX](/fr/CiteSeer)
 - [Fetching entries from DBLP](/fr/DBLP)
 - [Fetching entries from DOAJ](/fr/DOAJ)
 - [Fetching entries from GVK](/fr/GVK)
-- [Recherche Google Scholar](/fr/GoogleScholar)
-- [Recherche IEEEXplore](/fr/IEEEXplore)
-- [Recherche INSPIRE](/fr/INSPIRE)
 - [Fetching entries from MathSciNet](/fr/MathSciNet)
-- [Récupération d'entrées depuis Medline](/fr/Medline)
+- [Fetching entries from SAO/NASA Astrophysics Data System](/fr/ADS)
 - [Fetching entries from Springer](/fr/Springer)
 - [Fetching entries from arXiv](/fr/arXiv)
 - [Fetching entries from zbMATH](/fr/zbMATH)
+- [Recherche Google Scholar](/fr/GoogleScholar)
+- [Recherche IEEEXplore](/fr/IEEEXplore)
+- [Recherche INSPIRE](/fr/INSPIRE)
+- [Récupération d'entrées depuis CiteSeerX](/fr/CiteSeer)
+- [Récupération d'entrées depuis Medline](/fr/Medline)
+- [Récupération d'entrées depuis le portail *ACM*](/fr/ACMPortal)
 
 
 
@@ -129,7 +129,7 @@ title: Contenu de l’aide
 
 
 ## Divers
-- [License](/fr/License)
 - [Historique des révisions (en anglais)](/fr/RevisionHistory)
+- [License](/fr/License)
 
 

--- a/in/index.md
+++ b/in/index.md
@@ -15,83 +15,83 @@ title: Daftar Isi Bantuan
 
 
 ## FAQ
-- [Contributing](/in/FAQcontributing)
 - [General](/in/FAQgeneral)
 - [JabRef and Linux](/in/FAQlinux)
 - [JabRef and Mac OS X](/in/FAQosx)
+- [JabRef and Windows](/in/FAQwindows)
 - [Other](/in/FAQother)
 - [Sharing](/in/FAQsharing)
-- [JabRef and Windows](/in/FAQwindows)
+- [貢献方法](/in/FAQcontributing)
 
 
 ## Umum
-- [Menyimpan otomatis](/in/Autosave)
 - [Backup](/in/Backup)
-- [Jendela utama JabRef](/in/BaseFrame)
 - [Best Practices](/in/BestPractices)
 - [Command line use and options](/in/CommandLine)
-- [Penyunting entri](/in/EntryEditor)
 - [Installation](/in/Installation)
 - [JabRef](/in/JabRef)
+- [Jendela utama JabRef](/in/BaseFrame)
+- [Menyimpan otomatis](/in/Autosave)
+- [Penyunting entri](/in/EntryEditor)
 - [Remote operation](/in/Remote)
 
 
 ## Bidang dalam Entri
-- [Tentang *bibtex*](/in/Bibtex)
-- [Pengisian kata dalam bidang](/in/ContentSelector)
-- [PDF/PS/URL/DOI links in JabRef](/in/ExternalFiles)
-- [File links in JabRef](/in/FileLinks)
-- [Singkatan nama jurnal](/in/JournalAbbreviations)
 - [Bidang 'pemilik'](/in/Owner)
+- [Cap waktu entri](/in/TimeStamp)
+- [File links in JabRef](/in/FileLinks)
+- [PDF/PS/URL/DOI links in JabRef](/in/ExternalFiles)
+- [Pengisian kata dalam bidang](/in/ContentSelector)
 - [Set/clear/rename fields](/in/SetClearRenameFields)
+- [Singkatan nama jurnal](/in/JournalAbbreviations)
 - [Special Fields](/in/SpecialFields)
 - [Strings](/in/Strings)
-- [Cap waktu entri](/in/TimeStamp)
+- [Tentang *bibtex*](/in/Bibtex)
 
 
 ## Mencari dan mengurutkan entri
+- [Add unlinked PDFs including BibTeX data into the database](/in/FindUnlinkedFiles)
 - [Check integrity](/in/CheckIntegrity)
 - [Cleanup entries](/in/CleanupEntries)
 - [Find duplicates](/in/FindDuplicates)
-- [Add unlinked PDFs including BibTeX data into the database](/in/FindUnlinkedFiles)
 - [Get BibTeX data from DOI](/in/GetBibTeXDataFromDOI)
 - [Groups](/in/Groups)
 - [Menandai entri](/in/Marking)
 - [Merge entries](/in/MergeEntries)
+- [Pencarian](/in/Search)
 - [Replace string](/in/ReplaceString)
 - [Save actions](/in/SaveActions)
-- [Pencarian](/in/Search)
 - [Synchronize file links](/in/SynchroFileLinks)
 
 
 ## Pengaturan
-- [Customizing the BibTeX key generator](/in/BibtexKeyPatterns)
-- [Customizing entry types](/in/CustomEntryTypes)
 - [Customize key bindings](/in/CustomKeyBindings)
+- [Customizing entry types](/in/CustomEntryTypes)
+- [Customizing general fields](/in/GeneralFields)
+- [Customizing the BibTeX key generator](/in/BibtexKeyPatterns)
 - [Jendela propereti basisdata](/in/DatabaseProperties)
 - [Manage external file types](/in/ExternalFileTypes)
-- [Customizing general fields](/in/GeneralFields)
-- [Pengaturan pratampilan entri](/in/Preview)
 - [Manage protected terms](/in/ProtectedTerms)
+- [Pengaturan pratampilan entri](/in/Preview)
 - [Penyunting string](/in/StringEditor)
 
 
 ## Collaborative work
-- [Shared SQL Database](/in/SQLDatabase)
 - [Migration of pre-3.6 SQL databases into a shared SQL database](/in/SQLDatabaseMigration)
+- [Shared SQL Database](/in/SQLDatabase)
 - [Sharing a Bib(La)TeX Database](/in/SharedBibFile)
 
 
 ## Impor/Ekspor
-- [Penapis ekspor atursendiri](/in/CustomExports)
+- [Comparison of the Medline (txt), Medline (XML), and RIS format](/in/MedlineRIS)
 - [Custom import filters](/in/CustomImports)
 - [EndNote Export Filter](/in/EndNoteFilters)
+- [Export to an External SQL Database](/in/SQLExport)
 - [Import inspection window](/in/ImportInspectionDialog)
-- [Comparison of the Medline (txt), Medline (XML), and RIS format](/in/MedlineRIS)
 - [MS Office Bibliography xml format](/in/MsOfficeBibFieldMapping)
 - [New subdatabase based on AUX file](/in/NewBasedOnAux)
 - [OpenOffice/LibreOffice integration](/in/OpenOfficeIntegration)
-- [Export to an External SQL Database](/in/SQLExport)
+- [Penapis ekspor atursendiri](/in/CustomExports)
 - [XMP metadata support in JabRef](/in/XMP)
 
 
@@ -99,28 +99,28 @@ title: Daftar Isi Bantuan
 
 
 ### ... using publication identifiers
-- [Creating entries from SAO/NASA Astrophysics Data System](/in/ADStoBibTeX)
-- [Creating entries using the Digital Object Identifier (DOI)](/in/DOItoBibTeX)
 - [Creating entries from DiVA](/in/DiVAtoBibTeX)
-- [Creating entries using an ISBN number](/in/ISBNtoBibTeX)
 - [Creating entries from Medline](/in/MedlinetoBibTeX)
+- [Creating entries from SAO/NASA Astrophysics Data System](/in/ADStoBibTeX)
+- [Creating entries using an ISBN number](/in/ISBNtoBibTeX)
+- [Creating entries using the Digital Object Identifier (DOI)](/in/DOItoBibTeX)
 
 
 ### ... using online bibliographic database
-- [Pencarian melalui Portal ACM](/in/ACMPortal)
-- [Fetching entries from SAO/NASA Astrophysics Data System](/in/ADS)
-- [Impor entri dari CiteSeer](/in/CiteSeer)
 - [Fetching entries from DBLP](/in/DBLP)
 - [Fetching entries from DOAJ](/in/DOAJ)
 - [Fetching entries from GVK](/in/GVK)
 - [Fetching entries from Google Scholar](/in/GoogleScholar)
-- [Pencarian IEEEXplore](/in/IEEEXplore)
-- [Pencarian INSPIRE](/in/INSPIRE)
 - [Fetching entries from MathSciNet](/in/MathSciNet)
-- [Mengambil entri dari Medline](/in/Medline)
+- [Fetching entries from SAO/NASA Astrophysics Data System](/in/ADS)
 - [Fetching entries from Springer](/in/Springer)
 - [Fetching entries from arXiv](/in/arXiv)
 - [Fetching entries from zbMATH](/in/zbMATH)
+- [Impor entri dari CiteSeer](/in/CiteSeer)
+- [Mengambil entri dari Medline](/in/Medline)
+- [Pencarian IEEEXplore](/in/IEEEXplore)
+- [Pencarian INSPIRE](/in/INSPIRE)
+- [Pencarian melalui Portal ACM](/in/ACMPortal)
 
 
 

--- a/it/index.md
+++ b/it/index.md
@@ -15,45 +15,45 @@ title: Help contents
 
 
 ## FAQ
-- [Contributing](/it/FAQcontributing)
 - [General](/it/FAQgeneral)
 - [JabRef and Linux](/it/FAQlinux)
 - [JabRef and Mac OS X](/it/FAQosx)
+- [JabRef and Windows](/it/FAQwindows)
 - [Other](/it/FAQother)
 - [Sharing](/it/FAQsharing)
-- [JabRef and Windows](/it/FAQwindows)
+- [貢献方法](/it/FAQcontributing)
 
 
 ## General
 - [Autosave](/it/Autosave)
 - [Backup](/it/Backup)
-- [The JabRef main window](/it/BaseFrame)
 - [Best Practices](/it/BestPractices)
 - [Command line use and options](/it/CommandLine)
-- [The entry editor](/it/EntryEditor)
 - [Installation](/it/Installation)
 - [JabRef](/it/JabRef)
 - [Remote operation](/it/Remote)
+- [The JabRef main window](/it/BaseFrame)
+- [The entry editor](/it/EntryEditor)
 
 
 ## Fields
 - [About *BibTeX*](/it/Bibtex)
+- [Entry time stamps](/it/TimeStamp)
 - [Field content selector](/it/ContentSelector)
-- [PDF/PS/URL/DOI links in JabRef](/it/ExternalFiles)
 - [File links in JabRef](/it/FileLinks)
 - [Journal abbreviations](/it/JournalAbbreviations)
-- [The 'owner' field](/it/Owner)
+- [PDF/PS/URL/DOI links in JabRef](/it/ExternalFiles)
 - [Set/clear/rename fields](/it/SetClearRenameFields)
 - [Special Fields](/it/SpecialFields)
 - [Strings](/it/Strings)
-- [Entry time stamps](/it/TimeStamp)
+- [The 'owner' field](/it/Owner)
 
 
 ## Finding, sorting and cleaning entries
+- [Add unlinked PDFs including BibTeX data into the database](/it/FindUnlinkedFiles)
 - [Check integrity](/it/CheckIntegrity)
 - [Cleanup entries](/it/CleanupEntries)
 - [Find duplicates](/it/FindDuplicates)
-- [Add unlinked PDFs including BibTeX data into the database](/it/FindUnlinkedFiles)
 - [Get BibTeX data from DOI](/it/GetBibTeXDataFromDOI)
 - [Groups](/it/Groups)
 - [Mark entries](/it/Marking)
@@ -65,33 +65,33 @@ title: Help contents
 
 
 ## Setup
-- [Customizing the BibTeX key generator](/it/BibtexKeyPatterns)
-- [Customizing entry types](/it/CustomEntryTypes)
 - [Customize key bindings](/it/CustomKeyBindings)
-- [Database properties window](/it/DatabaseProperties)
-- [Manage external file types](/it/ExternalFileTypes)
+- [Customizing entry types](/it/CustomEntryTypes)
 - [Customizing general fields](/it/GeneralFields)
+- [Customizing the BibTeX key generator](/it/BibtexKeyPatterns)
+- [Database properties window](/it/DatabaseProperties)
 - [Entry preview setup](/it/Preview)
+- [Manage external file types](/it/ExternalFileTypes)
 - [Manage protected terms](/it/ProtectedTerms)
 - [The string editor](/it/StringEditor)
 
 
 ## Collaborative work
-- [Shared SQL Database](/it/SQLDatabase)
 - [Migration of pre-3.6 SQL databases into a shared SQL database](/it/SQLDatabaseMigration)
+- [Shared SQL Database](/it/SQLDatabase)
 - [Sharing a Bib(La)TeX Database](/it/SharedBibFile)
 
 
 ## Import/Export
+- [Comparison of the Medline (txt), Medline (XML), and RIS format](/it/MedlineRIS)
 - [Custom export filters](/it/CustomExports)
 - [Custom import filters](/it/CustomImports)
 - [EndNote Export Filter](/it/EndNoteFilters)
+- [Export to an External SQL Database](/it/SQLExport)
 - [Import inspection window](/it/ImportInspectionDialog)
-- [Comparison of the Medline (txt), Medline (XML), and RIS format](/it/MedlineRIS)
 - [MS Office Bibliography xml format](/it/MsOfficeBibFieldMapping)
 - [New subdatabase based on AUX file](/it/NewBasedOnAux)
 - [OpenOffice/LibreOffice integration](/it/OpenOfficeIntegration)
-- [Export to an External SQL Database](/it/SQLExport)
 - [XMP metadata support in JabRef](/it/XMP)
 
 
@@ -99,16 +99,15 @@ title: Help contents
 
 
 ### ... using publication identifiers
-- [Creating entries from SAO/NASA Astrophysics Data System](/it/ADStoBibTeX)
-- [Creating entries using the Digital Object Identifier (DOI)](/it/DOItoBibTeX)
 - [Creating entries from DiVA](/it/DiVAtoBibTeX)
-- [Creating entries using an ISBN number](/it/ISBNtoBibTeX)
 - [Creating entries from Medline](/it/MedlinetoBibTeX)
+- [Creating entries from SAO/NASA Astrophysics Data System](/it/ADStoBibTeX)
+- [Creating entries using an ISBN number](/it/ISBNtoBibTeX)
+- [Creating entries using the Digital Object Identifier (DOI)](/it/DOItoBibTeX)
 
 
 ### ... using online bibliographic database
 - [Fetching entries from ACM Portal](/it/ACMPortal)
-- [Fetching entries from SAO/NASA Astrophysics Data System](/it/ADS)
 - [Fetching entries from CiteSeerX](/it/CiteSeer)
 - [Fetching entries from DBLP](/it/DBLP)
 - [Fetching entries from DOAJ](/it/DOAJ)
@@ -116,8 +115,9 @@ title: Help contents
 - [Fetching entries from Google Scholar](/it/GoogleScholar)
 - [Fetching entries from IEEEXplore](/it/IEEEXplore)
 - [Fetching entries from INSPIRE-HEP](/it/INSPIRE)
-- [Fetching entries from MathSciNet](/it/MathSciNet)
 - [Fetching entries from MEDLINE](/it/Medline)
+- [Fetching entries from MathSciNet](/it/MathSciNet)
+- [Fetching entries from SAO/NASA Astrophysics Data System](/it/ADS)
 - [Fetching entries from Springer](/it/Springer)
 - [Fetching entries from arXiv](/it/arXiv)
 - [Fetching entries from zbMATH](/it/zbMATH)

--- a/ja/index.md
+++ b/ja/index.md
@@ -15,95 +15,95 @@ title: ヘルプ目次
 
 
 ## FAQ
-- [Contributing](/ja/FAQcontributing)
 - [General](/ja/FAQgeneral)
 - [JabRef and Linux](/ja/FAQlinux)
 - [JabRef and Mac OS X](/ja/FAQosx)
+- [JabRef and Windows](/ja/FAQwindows)
 - [Other](/ja/FAQother)
 - [Sharing](/ja/FAQsharing)
-- [JabRef and Windows](/ja/FAQwindows)
+- [貢献方法](/ja/FAQcontributing)
 
 
 ## 一般
-- [自動保存](/ja/Autosave)
 - [Backup](/ja/Backup)
-- [JabRef 基本ウィンドウ](/ja/BaseFrame)
-- [ベスト・プラクティス](/ja/BestPractices)
-- [コマンドラインの使用法とオプション](/ja/CommandLine)
-- [項目エディタ](/ja/EntryEditor)
-- [導入方法](/ja/Installation)
 - [JabRef](/ja/JabRef)
+- [JabRef 基本ウィンドウ](/ja/BaseFrame)
+- [コマンドラインの使用法とオプション](/ja/CommandLine)
+- [ベスト・プラクティス](/ja/BestPractices)
 - [リモート操作](/ja/Remote)
+- [導入方法](/ja/Installation)
+- [自動保存](/ja/Autosave)
+- [項目エディタ](/ja/EntryEditor)
 
 
 ## フィールド
 - [*BibTeX* について](/ja/Bibtex)
-- [フィールド内容選択メニュー](/ja/ContentSelector)
 - [JabRef における PDF/PS/URL/DOI リンク](/ja/ExternalFiles)
 - [JabRef におけるファイルリンク](/ja/FileLinks)
-- [学術誌名の短縮形](/ja/JournalAbbreviations)
 - [「owner」フィールド](/ja/Owner)
 - [フィールドを設定/クリア/名称変更](/ja/SetClearRenameFields)
-- [特殊フィールド](/ja/SpecialFields)
+- [フィールド内容選択メニュー](/ja/ContentSelector)
+- [学術誌名の短縮形](/ja/JournalAbbreviations)
 - [文字列に関するヘルプ](/ja/Strings)
+- [特殊フィールド](/ja/SpecialFields)
 - [項目の時間スタンプ](/ja/TimeStamp)
 
 
 ## 項目の検索と整序
+- [Add unlinked PDFs including BibTeX data into the database](/ja/FindUnlinkedFiles)
 - [Check integrity](/ja/CheckIntegrity)
 - [Cleanup entries](/ja/CleanupEntries)
-- [重複の検出](/ja/FindDuplicates)
-- [Add unlinked PDFs including BibTeX data into the database](/ja/FindUnlinkedFiles)
 - [Get BibTeX data from DOI](/ja/GetBibTeXDataFromDOI)
-- [グループ](/ja/Groups)
-- [項目の標識付け](/ja/Marking)
 - [Merge entries](/ja/MergeEntries)
 - [Replace string](/ja/ReplaceString)
 - [Save actions](/ja/SaveActions)
-- [検索](/ja/Search)
 - [Synchronize file links](/ja/SynchroFileLinks)
+- [グループ](/ja/Groups)
+- [検索](/ja/Search)
+- [重複の検出](/ja/FindDuplicates)
+- [項目の標識付け](/ja/Marking)
 
 
 ## 設定
 - [BibTeX鍵(キー)生成方法の調整](/ja/BibtexKeyPatterns)
-- [項目型の調整](/ja/CustomEntryTypes)
 - [Customize key bindings](/ja/CustomKeyBindings)
-- [データベース特性ウィンドウ](/ja/DatabaseProperties)
 - [Manage external file types](/ja/ExternalFileTypes)
+- [Manage protected terms](/ja/ProtectedTerms)
+- [データベース特性ウィンドウ](/ja/DatabaseProperties)
+- [文字列エディタ](/ja/StringEditor)
 - [汎用フィールドの調整](/ja/GeneralFields)
 - [項目プレビューの設定](/ja/Preview)
-- [Manage protected terms](/ja/ProtectedTerms)
-- [文字列エディタ](/ja/StringEditor)
+- [項目型の調整](/ja/CustomEntryTypes)
 
 
 ## 共同作業
+- [BibLaTeXデータベースを共有する](/ja/SharedBibFile)
 - [共有SQLデータベース](/ja/SQLDatabase)
 - [第3.6版以前のSQLデータベースから共有データベースへの移行](/ja/SQLDatabaseMigration)
-- [BibLaTeXデータベースを共有する](/ja/SharedBibFile)
 
 
 ## 読み込み/書き出し
-- [ユーザー書出フィルタ](/ja/CustomExports)
-- [ユーザー読込フィルタ](/ja/CustomImports)
 - [EndNote書出フィルタ](/ja/EndNoteFilters)
-- [読込検査ウィンドウ](/ja/ImportInspectionDialog)
-- [Medline (txt)形式とMedline (XML)形式およびRIS形式の比較](/ja/MedlineRIS)
+- [JabRefにおけるXMPメタデータ サポート](/ja/XMP)
 - [MS Office文献XML形式](/ja/MsOfficeBibFieldMapping)
+- [Medline (txt)形式とMedline (XML)形式およびRIS形式の比較](/ja/MedlineRIS)
 - [New subdatabase based on AUX file](/ja/NewBasedOnAux)
 - [OpenOffice.org / LibreOffice の統合](/ja/OpenOfficeIntegration)
+- [ユーザー書出フィルタ](/ja/CustomExports)
+- [ユーザー読込フィルタ](/ja/CustomImports)
 - [外部SQLデータベースへの書き出し](/ja/SQLExport)
-- [JabRefにおけるXMPメタデータ サポート](/ja/XMP)
+- [読込検査ウィンドウ](/ja/ImportInspectionDialog)
 
 
 ## ウェブから項目を取得する
 
 
 ### ... 刊行識別子を使用して
-- [Creating entries from SAO/NASA Astrophysics Data System](/ja/ADStoBibTeX)
-- [Digital Object Identifier (DOI)を使用して項目を取得するには](/ja/DOItoBibTeX)
-- [DiVAから項目を取得するには](/ja/DiVAtoBibTeX)
-- [ISBN番号を使用して項目を取得するには](/ja/ISBNtoBibTeX)
 - [Creating entries from Medline](/ja/MedlinetoBibTeX)
+- [Creating entries from SAO/NASA Astrophysics Data System](/ja/ADStoBibTeX)
+- [DiVAから項目を取得するには](/ja/DiVAtoBibTeX)
+- [Digital Object Identifier (DOI)を使用して項目を取得するには](/ja/DOItoBibTeX)
+- [ISBN番号を使用して項目を取得するには](/ja/ISBNtoBibTeX)
 
 
 ### ... オンライン書誌データベースを使用して
@@ -112,15 +112,15 @@ title: ヘルプ目次
 - [CiteSeerXから項目を取得するには](/ja/CiteSeer)
 - [DBLPから項目を取得するには](/ja/DBLP)
 - [DOAJから項目を取得するには](/ja/DOAJ)
+- [Fetching entries from MathSciNet](/ja/MathSciNet)
+- [Fetching entries from zbMATH](/ja/zbMATH)
 - [GVKから項目を取得するには](/ja/GVK)
 - [Google Scholarから項目を取得するには](/ja/GoogleScholar)
 - [IEEEXploreから項目を取得するには](/ja/IEEEXplore)
 - [INSPIRE-HEPから項目を取得するには](/ja/INSPIRE)
-- [Fetching entries from MathSciNet](/ja/MathSciNet)
 - [MEDLINEから項目を取得するには](/ja/Medline)
 - [Springerから項目を取得するには](/ja/Springer)
 - [arXivから項目を取得するには](/ja/arXiv)
-- [Fetching entries from zbMATH](/ja/zbMATH)
 
 
 


### PR DESCRIPTION
Fixes https://github.com/JabRef/help.jabref.org/issues/144.

Previously the items were sorted based on their filenames; now it's based on their actual title.
(This means they may be sorted differently in each language!)