### PR TITLE
Add a new special field marker [pageprefix]

### DIFF
--- a/en/BibtexKeyPatterns.md
+++ b/en/BibtexKeyPatterns.md
@@ -68,6 +68,7 @@ Several special field markers are offered, which extract only a specific part of
 #### Other key patterns
 
 -   **\[`firstpage`\]**: The number of the first page of the publication (Caution: this will return the lowest number found in the pages field, since BibTeX allows `7,41,73--97` or `43+`.)
+-   **\[`pageprefix`\]**: The non-digit prefix of pages (like "L" for L7) or "" if no non-digit prefix exists (like "" for `7,41,73--97`) .
 -   **\[`keywordN`\]**: Keyword number N from the “keywords” field, assuming keywords are separated by commas or semicolons.
 -   **\[`lastpage`\]**: The number of the last page of the publication (See the remark on `firstpage`)
 -   **\[`shortyear`\]**: The last 2 digits of the publication year


### PR DESCRIPTION
It returns the non-digit prefix of pages (like "L" of L7) or "" if no non-digit prefix is found (like "" for  7,41,73--97). 
cf. PR #2934 of JabRef/jabref
 
- [ ] If you added a new item or changed the localization: Did you run `c:\Python27\python _scripts\automate.py update -e`?
