### PR TITLE
Add Shorten DOI field formatter to Save actions page

### DIFF
--- a/en/SaveActions.md
+++ b/en/SaveActions.md
@@ -89,6 +89,9 @@ Removes all hyphenated line breaks in the field content.
 ## Remove line breaks
 Removes all line breaks in the field content.
 
+## Shorten DOI
+Shortens DOI to more human readable form.
+
 ## Unicode to LaTeX
 Converts Unicode characters to LaTeX encoding.
 


### PR DESCRIPTION
- [ ] If you added a new item or changed the localization: Did you run `c:\Python27\python _scripts\automate.py update -e`?

Shorten DOI field formatter was added in this merged PR: https://github.com/JabRef/jabref/pull/5276