### PR TITLE
Added Unpaywall fetching documentation

### DIFF
--- a/en/Unpaywall.md
+++ b/en/Unpaywall.md
@@ -1,0 +1,15 @@
+---
+title: Fetching entries from Unpaywall
+helpCategories: ["Fetching entries from the web", "... using online bibliographic database"]
+---
+
+# Fetching entries from Unpaywall
+
+[Unpaywall](https://unpaywall.org) is an open database with over 20 million free scholarly articles harvested from over 50,000 journals and open-access repositories around the globe. Sources for these articles include repositories run by renowned universities, governments, and scholarly societies. Unpaywall is integrated into thousands of existing search engines, library platforms, and information products, making articles easy to find, track, and use for your scholarly communication needs.
+
+The Unpaywall database has a very simple structure: it has one record for each article with a Crossref DOI. It harvests from many sources to find Open Access content, and then matches this content to these DOIs using content fingerprints. So for any given DOI, we know about any OA versions that exist anywhere.
+
+To fetch entries from Unpaywall indirectly through Crossref, choose **Search → Web search**, and the search interface will appear in the side pane. Select **Crossref** in the dropdown menu. To start a search, enter the words of your query, and press <kbd>Enter</kbd> or the **Fetch** button.
+
+The results are displayed in the [import inspection window](ImportInspectionDialog).
+In case an error occurs, it is shown in a popup.

--- a/en/UnpaywallHelp.md
+++ b/en/UnpaywallHelp.md
@@ -1,0 +1,4 @@
+---
+redirect:   /en/Unpaywall
+layout:     redirect
+---


### PR DESCRIPTION
Added new documentation that advertises Unpaywall as part of JabRef and includes instructions on how to access Unpaywall articles and data indirectly through Crossref article web search. Also added redirect page for Unpaywall help section.

Closes #190 

- [x] If you added a new item or changed the localization: Did you run `c:\Python27\python _scripts\automate.py update -e`?
